### PR TITLE
EUNJAN1210 / 1_week

### DIFF
--- a/Baekjoon/1_week/11478.py
+++ b/Baekjoon/1_week/11478.py
@@ -1,0 +1,9 @@
+s = input()
+
+result = set()
+for i in range(0,len(s)):
+    for j in range(i+1,len(s)+1):
+        result.add(s[i:j])
+
+print(len(result))
+


### PR DESCRIPTION
(11478번) 풀이 방법

문자열의 슬라이스를 응용해 부분 문자열을 찾기로 했습니다.
중복은 계산에서 배제해야하므로 set집합을 사용합니다.
모든 부분 문자열을 찾기 위한 슬라이스의 인덱스 패턴은 이렇습니다. (문자열의 길이는 5글자로 가정) [0:1][0:2][0:3][0:4][0:5]
[1:2][1:3][1:4][1:5]
[2:3][2:4][2:5]
[3:4][3:5]
[4:5]
반복적인 패턴을 볼 수 있으며, 첫번째 인덱스(i)는 range(0,len(s))의 범위를 가집니다. 두번째 인덱스는 첫번째 인덱스보다 항상 최소 1이상은 큰 값을 가져야하며 (반복적으로 증가합니다) 끝의 끝까지 스캔해야합니다.range(i+1,len(s)+1) for문으로 슬라이스의 첫번째와 두번째 인덱스를 생성하고 부분 문자열을 찾아 결과 집합을 생성합니다. 집합의 길이를 구하면 정답을 구할 수 있습니다.

*수정이 너무 잦고, 테스트를 해보니 시간초과가 나와 다듬다보니 재업로드를 하게 됐습니다. -문제 원인은 처음부터 set집합을 사용하는 것이 아닌 list로 결과 값을 받아 for문으로 다시 한번 중복을 다듬는 것 때문이었습니다.